### PR TITLE
Jhaage/add ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI Workflow
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  release:
+    types:
+      - created
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Set up Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+
+    - name: Run tests
+      run: cargo test
+
+  version:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Set up Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+
+    - name: Install cargo-release
+      run: cargo install cargo-release
+
+    - name: Run cargo-release
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      run: cargo release patch --no-publish

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 /target/
 /examples/sample_api/target/
 
+# Ignore local .env
+.env
+
 # Ignore our default output directory for generated tests
 /output/
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,4 +42,4 @@ name = "run-dev"
 path = "run-dev.rs"
 
 [badges]
-actions = { status = true }
+actions = { status = "true" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,14 @@
 name = "swagger-test-generator"
 version = "0.1.0"
 edition = "2021"
+description = "A tool to generate test cases from Swagger/OpenAPI specifications."
+license = "MIT"
+repository = "https://github.com/jhaage/swagger-test-generator"
+homepage = "https://github.com/jhaage/swagger-test-generator"
+documentation = "https://docs.rs/swagger-test-generator"
+keywords = ["swagger", "openapi", "test", "generator"]
+categories = ["development-tools", "testing"]
+readme = "README.md"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
@@ -26,8 +34,12 @@ pathdiff = "0.2"
 tokio = { version = "1", features = ["full"] }
 assert_cmd = "2.0"
 predicates = "1.0"
+cargo-release = "0.24"
 
 # Custom targets for development workflows
 [[bin]]
 name = "run-dev"
 path = "run-dev.rs"
+
+[badges]
+actions = { status = true }

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ A command-line tool written in Rust that generates test cases from Swagger/OpenA
 
 ### From crates.io
 
+Coming Soon!
+
 ```bash
 cargo install swagger-test-generator
 ```

--- a/release.toml
+++ b/release.toml
@@ -1,0 +1,15 @@
+[release]
+# Specify the default release level (e.g., patch, minor, major)
+level = "patch"
+
+# Update the Cargo.lock file during release
+update-lock = true
+
+# Push changes to the repository after release
+git-push = true
+
+# Create a tag for the release
+tag = true
+
+# Specify the branch to release from
+branch = "main"


### PR DESCRIPTION
Adds CI pipeline using Github Actions and cargo-release. Not yet publishing to crates.io.